### PR TITLE
Put Ludography after references in main.tex

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,7 +1,6 @@
 \documentclass[sigconf]{acmart}
 \usepackage[utf8]{inputenc}
 
-
 % --- LUDOGRAPHY ---
 \usepackage[resetlabels]{multibib}
 \newcites{game}{Ludography}
@@ -32,16 +31,16 @@ This \LaTeX source is an example of a ludography, featuring games like \emph{Bio
 
 % --- LUDOGRAPHY ---
 
-% set formatting for ludography
-\renewcommand{\bibnumfmt}[1]{[\citegameprefix#1]}%  
-\bibliographystylegame{ACM-Reference-Format}
-\bibliographygame{games}
-
 % set formatting back for other references
 \renewcommand{\bibnumfmt}[1]{[#1]}%  
 \bibliographystyle{ACM-Reference-Format}
 \bibliography{ref}
 % Note: this may produce warnings that game refs did not have a database entry
-% -----------------
 
+% set formatting for ludography
+\renewcommand{\bibnumfmt}[1]{[\citegameprefix#1]}%  
+\bibliographystylegame{ACM-Reference-Format}
+\bibliographygame{games}
+
+% -----------------
 \end{document}


### PR DESCRIPTION
Hi Josh,
Super glad you put this together and pushed us to handle this. I discussed it with the other paper chairs and we would like to follow exactly what you have. The only difference is we think the Ludography should come after the normal References since it is kind of an extra (appendix-like thing). Would you consider accepting this pull request and then I will refer to your repo in a blog post that we put up with some directions on Ludographies?